### PR TITLE
include figure in brainlife app

### DIFF
--- a/main
+++ b/main
@@ -19,3 +19,16 @@ mkdir -p out_dir
 
 # Run the actual python code
 singularity exec docker://brainlife/mne:0.23dev python3 detect_alpha_peak.py
+
+#store PSD plot with alpha peak on product.json
+cat << EOF > product.json
+{
+    "brainlife": [
+        { 
+            "type": "image/png", 
+	        "name": "Alpha peak",
+            "base64": "$(base64 -w 0 out_dir/psd_figure.png)"
+        }
+    ]
+}
+EOF


### PR DESCRIPTION
If you save your png figure in out_dir/ folder for example as psd_figure.png this should be able to show it